### PR TITLE
task: add explicit toString() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ composer require xaevik/cuid2
 
 ```php
 <?php
+
+declare(strict_types=1);
+
 require_once 'vendor/autoload.php';
 
 // new (default length of 24)
@@ -27,4 +30,8 @@ echo $cuid; // hw8kkckkgwkk0oo0gkw0o8sg
 // new (with custom length)
 $cuid = new Xaevik\Cuid2\Cuid2(10);
 echo $cuid; // psk8844ck4
+
+// explicit toString call
+$cuid = new Xaevik\Cuid2\Cuid2();
+echo $cuid->toString(); // iqdizzredw2uibe2anrijgv8
 ```

--- a/src/Cuid2.php
+++ b/src/Cuid2.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Xaevik\Cuid2;
 
 use Exception;
+use JsonSerializable;
 use OutOfRangeException;
 
-final class Cuid2
+final class Cuid2 implements JsonSerializable
 {
     /** @readonly */
     private int $counter;
@@ -78,6 +79,11 @@ final class Cuid2
         return !$result ? [] : $result;
     }
 
+    public function toString(): string
+    {
+        return $this->__toString();
+    }
+
     public function __toString(): string
     {
         $hash = hash_init('sha3-512');
@@ -98,5 +104,13 @@ final class Cuid2
         }
 
         return $this->prefix . substr($result, 0, $this->length - 1);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function jsonSerialize(): string
+    {
+        return $this->toString();
     }
 }

--- a/tests/Cuid2Test.php
+++ b/tests/Cuid2Test.php
@@ -36,4 +36,16 @@ class Cuid2Test extends TestCase
 
         $_ = new Cuid2(48);
     }
+
+    public function testExplicitToString(): void
+    {
+        $cuid = new Cuid2();
+
+        $value = $cuid->toString();
+
+        $result = strlen($value) === 24 &&
+            ctype_alnum($value);
+
+        $this->assertTrue($result);
+    }
 }


### PR DESCRIPTION
Resolves #7 

Adds an explicit `toString()` for cases where `declare(strict_types=1)` is not in use or supported.

Signed-off-by: Alan Brault <alan.brault@visus.io>